### PR TITLE
Use named volume for vendor files to allow editing inside container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,9 @@ services:
 #            docker: "true"
         volumes:
             - ./www:/var/www
+            - vendorfiles-slim-taxonomy:/var/www/html/app/vendor
             - ./env:/var/env
 
 volumes:
     mysql-slim-taxonomy:
+    vendorfiles-slim-taxonomy:


### PR DESCRIPTION
Use named volume for vendor files to allow them to be edited inside the container using php composer. Source:  https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder